### PR TITLE
Add pyenv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pyenv
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
`pyenv` is the suggested virtualenv name in the README. Therefore, this adds this name to be ignored under git VCS.